### PR TITLE
Rename to Transfer Size Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Content Size Policy
+# Transfer Size Policy
 
-**Goal: enable developers to set and enforce limits on content size used by nested contexts (i.e. iframes).**
+**Goal: enable developers to set and enforce limits on network usage by nested contexts (i.e. iframes).**
 
 Today the top-level frame is unable to audit or enforce size limits on resources used by a nested context. For example, the developer may take great care to optimize their assets to fit within a specific quota, but the moment they add a third party resource that uses (or injects) a nested context, they have no way to track or enforce limits on the resulting size.
 
@@ -8,7 +8,7 @@ In practice, this can result in mis{behaving, configured} parties fetching large
 
 ```html
   <!-- insert vigorous handwaving here -->
-  <iframe max-content-size="300kb" src="...">
+  <iframe max-transfer-size="300kb" src="...">
   <!-- alternatively, header mechanism to set similar limits -->
 ```
 
@@ -17,7 +17,7 @@ The above limits intend to enforce the total amount of resources used by the fra
 ## Enforcement
 Once a frame's threshold has been reached, the frame is marked as a violating frame and all of its (and its children's) in-flight resource requests are cancelled and future requests are aborted.
 
-For privacy purposes (as described below) there is a limit to the number of violations that can occur per top-level page navigation. After the limit has been reached, all frames with a max-content-size (and their children) will abort requests.
+For privacy purposes (as described below) there is a limit to the number of violations that can occur per top-level page navigation. After the limit has been reached, all frames with a max-transfer-size (and their children) will abort requests.
 
 As an example, suppose the violation limit is 10 per navigation. This means that if you have 11 iframes with size policy and 10 of them exceed their max size, then the 11th will also stop loading.
 
@@ -29,9 +29,9 @@ TBD - Should the frame be informed that it has a size constraint? Should it be i
 
 ## Privacy & Security
 
-The browser can't enforce the exact max-content-size as provided to it, as that could be used to expose the precise size of cross-origin resources. Knowing response size of a cross-origin resource can reveal information about its contents and/or user state (e.g., authenticated vs log-in page response).
+The browser can't enforce the exact max-transfer-size as provided to it, as that could be used to expose the precise size of cross-origin resources. Knowing response size of a cross-origin resource can reveal information about its contents and/or user state (e.g., authenticated vs log-in page response).
 
-In order to prevent size policy from leaking the precise size of cross-origin resources, the enforcement is fuzzy and the number of violations is limited. The actual enforced max size for a frame is hidden from the page, but it's a function of the max size that includes a random number of bytes (the random pad). The random distribution is chosen to statistically reveal no more information than simple [network timing](https://www.igvita.com/2016/08/26/stop-cross-site-timing-attacks-with-samesite-cookies/) given a limited number of samples.
+In order to prevent the policy from leaking the precise size of cross-origin resources, the enforcement is fuzzy and the number of violations is limited. The actual enforced max size for a frame is hidden from the page, but it's a function of the max size that includes a random number of bytes (the random pad). The random distribution is chosen to statistically reveal no more information than simple [network timing](https://www.igvita.com/2016/08/26/stop-cross-site-timing-attacks-with-samesite-cookies/) given a limited number of samples.
 
 To prevent statistical defeat of the random pad, the number of size policy violations that may occur per top-level navigation will be fixed to a small number, such as 10. After the maximum number of size policy violations have occurred, all frames with size policies will be considered in violation and won't be able to load resources.
 


### PR DESCRIPTION
We'd still need to rename the repo. Fixes #9.